### PR TITLE
Enable optional params to the Get Item API call

### DIFF
--- a/remote.js
+++ b/remote.js
@@ -97,8 +97,8 @@ class RemoteInstance {
     return this._get(`tables/${table}/rows`, params);
   }
 
-  getItem(table = requiredParam('table'), id = requiredParam('id')) {
-    return this._get(`tables/${table}/rows/${id}`);
+  getItem(table = requiredParam('table'), id = requiredParam('id'), params = {}) {
+    return this._get(`tables/${table}/rows/${id}`, params);
   }
 
   updateItem(table = requiredParam('table'), id = requiredParam('id'), data = requiredParam('data')) {


### PR DESCRIPTION
According to [API docs for v1.1](https://api.getdirectus.com/1.1/#Get_Item), the `Get Item` endpoint supports optional `depth` and `preview` arguments.

In other SDK functions such as `getItems`, optional arguments are passed on using the `params` argument. 
In `getItem` this is currently not possible. Because I needed to specify the `depth` argument, I tried adding the `params` argument which worked perfectly fine.

Please review and let me know what you think.
Thank you very much for consideration, looking forward to any kind of feedback.