### PR TITLE
Add buble rollup plugin

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "@directus/sdk-js",
-  "version": "3.6.1",
+  "version": "3.7.2",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/rollup.config.js
+++ b/rollup.config.js
@@ -4,6 +4,7 @@ import json from 'rollup-plugin-json';
 import { terser } from 'rollup-plugin-terser';
 import builtins from 'rollup-plugin-node-builtins';
 import globals from 'rollup-plugin-node-globals';
+import buble from 'rollup-plugin-buble';
 import pkg from './package.json';
 
 export default [
@@ -21,6 +22,9 @@ export default [
       commonjs(),
       globals(),
       builtins(),
+      buble({
+        exclude: ['node_modules/**'],
+      }),
       json(),
       terser(),
     ],


### PR DESCRIPTION
Removes ES6 code syntax from the final bundle.